### PR TITLE
Fix for PEP 257

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -144,3 +144,4 @@ Contributors
 - Skyler Grey <sky@a.starrysky.fyi>
 - Emil Velikov <emil.l.velikov@gmail.com>
 - Linnea Gräf <nea@nea.moe>
+- Charlie Jenkins <charlie@rivosinc.com>

--- a/changelog.d/changed/removed-space-before-docstring.md
+++ b/changelog.d/changed/removed-space-before-docstring.md
@@ -1,0 +1,2 @@
+- To conform to PEP 257, do not put a space before a docstring at the beginning
+  of python formatted files. (#1136)

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -228,6 +228,48 @@ def test_find_and_replace_no_header():
     )
 
 
+def test_find_and_replace_no_header_docstring():
+    """Given text with docstring and without header, add a header."""
+    info = ReuseInfo({"GPL-3.0-or-later"}, {"SPDX-FileCopyrightText: Jane Doe"})
+    text = '"""docstring"""'
+    expected = cleandoc(
+        """
+        # SPDX-FileCopyrightText: Jane Doe
+        #
+        # SPDX-License-Identifier: GPL-3.0-or-later
+        \"\"\"docstring\"\"\"
+        """
+    )
+
+    assert (
+        find_and_replace_header(text, info)
+        == add_new_header(text, info)
+        == expected
+    )
+
+
+def test_find_and_replace_no_header_multiline_docstring():
+    """Given text with multiline docstring and without header, add a header."""
+    info = ReuseInfo({"GPL-3.0-or-later"}, {"SPDX-FileCopyrightText: Jane Doe"})
+    text = '"""docstring\ndocstring continued\n"""'
+    expected = cleandoc(
+        """
+        # SPDX-FileCopyrightText: Jane Doe
+        #
+        # SPDX-License-Identifier: GPL-3.0-or-later
+        \"\"\"docstring
+        docstring continued
+        \"\"\"
+        """
+    )
+
+    assert (
+        find_and_replace_header(text, info)
+        == add_new_header(text, info)
+        == expected
+    )
+
+
 def test_find_and_replace_verbatim():
     """Replace a header with itself."""
     info = ReuseInfo()
@@ -454,6 +496,42 @@ def test_find_and_replace_preserve_newline():
             """
         )
         + "\n"
+    )
+
+    assert find_and_replace_header(text, info) == text
+
+
+def test_find_and_replace_preserve_no_newline_docstring():
+    """If the file content doesn't have a newline and has a docstring,
+    don't add a newline."""
+
+    info = ReuseInfo()
+    text = cleandoc(
+        """
+            # SPDX-FileCopyrightText: Jane Doe
+            #
+            # SPDX-License-Identifier: GPL-3.0-or-later
+            \"\"\"docstring\"\"\"
+            """
+    )
+
+    assert find_and_replace_header(text, info) == text
+
+
+def test_find_and_replace_preserve_no_newline_mulitline_docstring():
+    """If the file content doesn't have a newline and has a docstring,
+    don't add a newline."""
+
+    info = ReuseInfo()
+    text = cleandoc(
+        """
+            # SPDX-FileCopyrightText: Jane Doe
+            #
+            # SPDX-License-Identifier: GPL-3.0-or-later
+            \"\"\"docstring
+            docstring continued
+            \"\"\"
+            """
     )
 
     assert find_and_replace_header(text, info) == text


### PR DESCRIPTION
Docstrings are defined in PEP 257 as "A docstring is a string literal that occurs as the first statement in a module, function, class, or method definition." When reuse adds a header, it forcibly adds a space before the docstring violating this principle.

When the style is set to Python and the first line in the file is a docstring, do not add a space between the license and the docstring.

Upstream PR https://github.com/fsfe/reuse-tool/pull/1136.